### PR TITLE
Improve performance of intersection detection

### DIFF
--- a/lib/wormbots/mating.rb
+++ b/lib/wormbots/mating.rb
@@ -13,7 +13,7 @@ class Mating
   private
 
   def intersection_with_another_fertile_worm
-    fertile_worms.each do |fertile_worm|
+    fertile_worms_in_proximity.each do |fertile_worm|
       if (intersection = intersection(fertile_worm))
         return intersection
       end
@@ -22,8 +22,20 @@ class Mating
     nil
   end
 
+  def fertile_worms_in_proximity
+    fertile_worms.reject do |fertile_worm|
+      fertile_min_x, fertile_max_x = fertile_worm.coordinates.minmax_by(&:x)
+      fertile_min_y, fertile_max_y = fertile_worm.coordinates.minmax_by(&:y)
+      worm_min_x, worm_max_x = @worm.coordinates.minmax_by(&:x)
+      worm_min_y, worm_max_y = @worm.coordinates.minmax_by(&:y)
+
+      fertile_max_x.x < worm_min_x.x || fertile_min_x.x > worm_max_x.x ||
+        fertile_max_y.y < worm_min_y.y || fertile_min_y.y > worm_max_y.y
+    end
+  end
+
   def fertile_worms
-    @other_worms.select { |worm| worm.fertile? }
+    @other_worms.select(&:fertile?)
   end
 
   def intersection(other_worm)

--- a/lib/wormbots/world.rb
+++ b/lib/wormbots/world.rb
@@ -14,18 +14,16 @@ class World
   end
 
   def populate
-    INITIAL_WORMS.times { spawn_worm }
+    @worms = INITIAL_WORMS.times.map { spawn_worm }
   end
 
   def tick
-    @worms.dup.each do |worm|
+    @worms.each do |worm|
       worm.live
       attempt_to_mate(worm)
-
-      if worm.decomposed
-        @worms.delete(worm)
-      end
     end
+
+    @worms.reject!(&:decomposed)
   end
 
   def data_points
@@ -42,16 +40,21 @@ class World
 
   def attempt_to_mate(worm)
     intersection_coordinates = Mating.new(worm, @worms).intersection_coordinates
+
     if intersection_coordinates
-      rand(1..4).times { spawn_worm(intersection_coordinates) }
+      spawn_offsprings(intersection_coordinates)
       worm.defertilize
+    end
+  end
+
+  def spawn_offsprings(coordinates)
+    rand(1..4).times do
+      @worms << spawn_worm(coordinates)
     end
   end
 
   def spawn_worm(coordinates = Geometry.random_coordinate)
     point = Point.new(coordinates[0], coordinates[1], true)
-    worm = Worm.new(point, Navigation.random_direction)
-    @worms << worm
-    worm
+    Worm.new(point, Navigation.random_direction)
   end
 end

--- a/spec/wormbots/mating_spec.rb
+++ b/spec/wormbots/mating_spec.rb
@@ -41,7 +41,12 @@ describe Mating, '#intersection_coordinates' do
   end
 
   def mating_factory(worms)
-    world_worms = worms.map { |worm_attributes| double(:worm, worm_attributes) }
+    world_worms = worms.map do |worm_attributes|
+      coords = worm_attributes[:coordinates].map do |coord|
+        Point.new(coord.first, coord.last)
+      end
+      instance_double('Worm', worm_attributes.merge(coordinates: coords))
+    end
     Mating.new(world_worms.first, world_worms)
   end
 end

--- a/spec/wormbots/world_spec.rb
+++ b/spec/wormbots/world_spec.rb
@@ -24,8 +24,8 @@ describe World, '#tick' do
 
   context 'when two worms can be mated' do
     it 'mates worms' do
-      worm1 = worm_factory(coordinates: [[10, 10]])
-      worm2 = worm_factory(coordinates: [[10, 10]])
+      worm1 = worm_factory(coordinates: [Point.new(10, 10)], fertile?: true)
+      worm2 = worm_factory(coordinates: [Point.new(10, 10)], fertile?: true)
       world = world_factory(worm1, worm2)
 
       expect { world.tick }.to change { world.worms.size }
@@ -46,12 +46,13 @@ describe World, '#tick' do
     end
   end
 
-  context 'after 4000 ticks' do
-    it 'simulates a period of worm lives' do
+  context 'when simulating a long time' do
+    it 'does not allow worms go outside the world boundaries' do
+      long_time = 2000
       world = world_factory
       world.populate
 
-      4000.times { world.tick }
+      long_time.times { world.tick }
 
       world.worms.each do |worm|
         worm.coordinates.each do |point|
@@ -91,10 +92,10 @@ end
 def worm_factory(attributes = {})
   default_attributes = {
     live: nil,
-    fertile?: true,
+    fertile?: false,
     decomposed: false,
     defertilize: nil,
     coordinates: []
   }
-  double(:worm, default_attributes.merge(attributes))
+  instance_double('Worm', default_attributes.merge(attributes))
 end


### PR DESCRIPTION
Intersection detection is one of the bigger performance issues,
because the algorithm looks for an intersection between each fertile
worm.
We can do some preliminary filtering of worms that aren't close to each
other. If one worm isn't close to the other one on the X or Y axis, then
there is no point in looking for intersection. Thus we can filter on
proximity.

Also, do some trivial refactoring of `World`.